### PR TITLE
feat(controllers/playlist): pass childNodeBase via GET request

### DIFF
--- a/src/controllers/playlist.ts
+++ b/src/controllers/playlist.ts
@@ -8,7 +8,7 @@ interface M3u8Entry {
 }
 
 
-const getPlaylist = async (city: string, baseUrl: string) => {
+const getPlaylist = async (city: string, baseUrl: string, childNodeBase?: string) => {
     try {
         if (city) {
             const playlistUrl = buildPlaylistUrl(city);
@@ -21,7 +21,7 @@ const getPlaylist = async (city: string, baseUrl: string) => {
 
             let processedPlaylist = `#EXTM3U x-tvg-url="${baseUrl}/epg/${city}"\n\n`;
 
-            const playlistEntries = entries.map(createM3u8Entry).join('');
+            const playlistEntries = entries.map(e => createM3u8Entry(e, childNodeBase)).join('');
 
             processedPlaylist += playlistEntries;
 
@@ -113,7 +113,7 @@ function addChannelNumber(data: M3u8Entry[]): void {
 
 }
 
-function createM3u8Entry(entry: M3u8Entry): string {
+function createM3u8Entry(entry: M3u8Entry, childNodeBase?: string): string {
     const excludeIds = exclude_channels_prefix;
     if (excludeIds.some(id => String(entry['tvg-id']).startsWith(id))) {
         return '';
@@ -126,8 +126,8 @@ function createM3u8Entry(entry: M3u8Entry): string {
         .map(([key, value]) => `${key.replace(/_/g, '-')}="${value}"`)
         .join(' ');
 
-    if (process.env.CHDVR_CHILDNODE) {
-        entry.url = `${process.env.CHDVR_CHILDNODE}/devices/ANY/channels/${entry.channel_number}/hls/stream.m3u8?codec=copy`;
+    if (childNodeBase) {
+        entry.url = `${childNodeBase}/devices/ANY/channels/${entry.channel_number}/hls/stream.m3u8?codec=copy`;
     }
     return `#EXTINF:-1 ${properties}, ${channelName}\n${entry.url}\n\n`;
 }

--- a/src/routes/playlist.ts
+++ b/src/routes/playlist.ts
@@ -12,7 +12,8 @@ router.get('/:city', async (req, res) => {
                 const protocol = req.protocol;
                 const host = req.get('host');
                 const baseUrl = `${protocol}://${host}`;
-                const playlist = await getPlaylist(req.params.city, baseUrl);
+                const childNodeBase = req.query.childNodeBase;
+                const playlist = childNodeBase? await getPlaylist(req.params.city, baseUrl, String(childNodeBase)) : await getPlaylist(req.params.city, baseUrl);
                 res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
                 res.send(playlist);
             } catch (e) {


### PR DESCRIPTION
This is why you don't make new stuff at 3am at night... totally offed up the approach!!  

Get Playlist now activates from/gets the Channels DVR child server base URL from a `?childNodeBase=http://childserver:8089` query param